### PR TITLE
Add South African Languages

### DIFF
--- a/five.js
+++ b/five.js
@@ -20,7 +20,8 @@
 
     return anotherNumber;
   };
-
+  
+  five.afrikaans = function() { return 'vyf'; };
   five.arabic = function() { return 'خمسة'; };
   five.azerbaijani = function() { return 'beş'; };
   five.basque = function() { return 'bost'; };
@@ -92,6 +93,10 @@
   five.thai = function() { return 'ห้า'; };
   five.ukrainian = function() { return 'п’ять'; };
   five.welsh = function() { return 'pump'; };
+  five.isixhosa = function() { return 'zinhlanu'; };
+  five.xhosa = five.isixhosa;
+  five.isizulu = function() { return 'okuhlanu'; };
+  five.zulu = five.isizulu;
 
   five.morseCode = function() { return '.....'; };
   five.base = function(i) { return five().toString(i); }


### PR DESCRIPTION
This adds Afrikaans, isiZulu, and isiXhosa translations for 'five'. If anyone else speaks some of the more exotic south african languages such as Northern/Southern Sesotho, Tshivenda, Sepedi, Xitsonga, etc then please feel free to to submit a PR to my branch.

Also aliased isiZulu and isiXhosa to their colloquial names Xhosa and Zulu.